### PR TITLE
Fix the module.xml file

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xs">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Autocompleteplus_Autosuggest" setup_version="4.5.8">
-        <sequence/>
+        <sequence>
+            <module name="Magento_Config"/>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Backend"/>
+            <module name="Magento_CatalogInventory"/>
+            <module name="Magento_CatalogSearch"/>
+            <module name="Magento_Checkout"/>
+            <module name="Magento_ConfigurableProduct"/>
+            <module name="Magento_Customer"/>
+            <module name="Magento_Eav"/>
+            <module name="Magento_GroupedProduct"/>
+            <module name="Magento_Review"/>
+            <module name="Magento_Sales"/>
+            <module name="Magento_Search"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_Wishlist"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
The module.xml file had a bad XSD reference and was missing the required modules to define load order. This missing load order information was causing a fresh install that included the module to fail during the DB setup process. This appeared when running the M2 integration testing framework.